### PR TITLE
refactor patch embed and patch merge and fix pretrain

### DIFF
--- a/mmdet/models/utils/ckpt_convert.py
+++ b/mmdet/models/utils/ckpt_convert.py
@@ -1,3 +1,9 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+# This script consists of several convert functions which
+# can modify the weights of model in original repo to be
+# pre-trained weights.
+
 from collections import OrderedDict
 
 import torch

--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -16,7 +16,6 @@ from mmcv.cnn.bricks.transformer import (BaseTransformerLayer,
 from mmcv.runner.base_module import BaseModule
 from mmcv.utils import to_2tuple
 from torch.nn.init import normal_
-from torch.nn.modules.utils import _pair as to_2tuple
 
 from mmdet.models.utils.builder import TRANSFORMER
 
@@ -28,6 +27,36 @@ except ImportError:
         '`MultiScaleDeformableAttention` in MMCV has been moved to '
         '`mmcv.ops.multi_scale_deform_attn`, please update your MMCV')
     from mmcv.cnn.bricks.transformer import MultiScaleDeformableAttention
+
+
+def nlc_to_nchw(x, hw_shape):
+    """Convert [N, L, C] shape tensor to [N, C, H, W] shape tensor.
+
+    Args:
+        x (Tensor): The input tensor of shape [N, L, C] before convertion.
+        hw_shape (Sequence[int]): The height and width of output feature map.
+
+    Returns:
+        Tensor: The output tensor of shape [N, C, H, W] after convertion.
+    """
+    H, W = hw_shape
+    assert len(x.shape) == 3
+    B, L, C = x.shape
+    assert L == H * W, 'The seq_len doesn\'t match H, W'
+    return x.transpose(1, 2).reshape(B, C, H, W).contiguous()
+
+
+def nchw_to_nlc(x):
+    """Flatten [N, C, H, W] shape tensor to [N, L, C] shape tensor.
+
+    Args:
+        x (Tensor): The input tensor of shape [N, C, H, W] before convertion.
+
+    Returns:
+        Tensor: The output tensor of shape [N, L, C] after convertion.
+    """
+    assert len(x.shape) == 4
+    return x.flatten(2).transpose(1, 2).contiguous()
 
 
 class AdaptivePadding(nn.Module):
@@ -1129,127 +1158,3 @@ class DynamicConv(BaseModule):
         features = self.activation(features)
 
         return features
-
-
-def nlc_to_nchw(x, hw_shape):
-    """Convert [N, L, C] shape tensor to [N, C, H, W] shape tensor.
-
-    Args:
-        x (Tensor): The input tensor of shape [N, L, C] before convertion.
-        hw_shape (Sequence[int]): The height and width of output feature map.
-
-    Returns:
-        Tensor: The output tensor of shape [N, C, H, W] after convertion.
-    """
-    H, W = hw_shape
-    assert len(x.shape) == 3
-    B, L, C = x.shape
-    assert L == H * W, 'The seq_len doesn\'t match H, W'
-    return x.transpose(1, 2).reshape(B, C, H, W).contiguous()
-
-
-def nchw_to_nlc(x):
-    """Flatten [N, C, H, W] shape tensor to [N, L, C] shape tensor.
-
-    Args:
-        x (Tensor): The input tensor of shape [N, C, H, W] before convertion.
-
-    Returns:
-        Tensor: The output tensor of shape [N, L, C] after convertion.
-    """
-    assert len(x.shape) == 4
-    return x.flatten(2).transpose(1, 2).contiguous()
-
-
-class PatchEmbed(BaseModule):
-    """Image to Patch Embedding V2.
-
-    We use a conv layer to implement PatchEmbed.
-    Args:
-        in_channels (int): The num of input channels. Default: 3.
-        embed_dims (int): The dimensions of embedding. Default: 768.
-        conv_type (dict, optional): The config dict for conv layers type
-            selection. Default: None.
-        kernel_size (int): The kernel_size of embedding conv. Default: 16.
-        stride (int): The slide stride of embedding conv.
-            Default: None (Default to be equal with kernel_size).
-        padding (int): The padding length of embedding conv. Default: 0.
-        dilation (int): The dilation rate of embedding conv. Default: 1.
-        pad_to_patch_size (bool, optional): Whether to pad feature map shape
-            to multiple patch size. Default: True.
-        norm_cfg (dict, optional): Config dict for normalization layer.
-        init_cfg (`mmcv.ConfigDict`, optional): The Config for initialization.
-            Default: None.
-    """
-
-    def __init__(self,
-                 in_channels=3,
-                 embed_dims=768,
-                 conv_type=None,
-                 kernel_size=16,
-                 stride=16,
-                 padding=0,
-                 dilation=1,
-                 pad_to_patch_size=True,
-                 norm_cfg=None,
-                 init_cfg=None):
-        super(PatchEmbed, self).__init__()
-
-        self.embed_dims = embed_dims
-        self.init_cfg = init_cfg
-
-        if stride is None:
-            stride = kernel_size
-
-        self.pad_to_patch_size = pad_to_patch_size
-
-        # The default setting of patch size is equal to kernel size.
-        patch_size = kernel_size
-        if isinstance(patch_size, int):
-            patch_size = to_2tuple(patch_size)
-        elif isinstance(patch_size, tuple):
-            if len(patch_size) == 1:
-                patch_size = to_2tuple(patch_size[0])
-            assert len(patch_size) == 2, \
-                f'The size of patch should have length 1 or 2, ' \
-                f'but got {len(patch_size)}'
-
-        self.patch_size = patch_size
-
-        # Use conv layer to embed
-        conv_type = conv_type or 'Conv2d'
-        self.projection = build_conv_layer(
-            dict(type=conv_type),
-            in_channels=in_channels,
-            out_channels=embed_dims,
-            kernel_size=kernel_size,
-            stride=stride,
-            padding=padding,
-            dilation=dilation)
-
-        if norm_cfg is not None:
-            self.norm = build_norm_layer(norm_cfg, embed_dims)[1]
-        else:
-            self.norm = None
-
-    def forward(self, x):
-        H, W = x.shape[2], x.shape[3]
-
-        # TODO: Process overlapping op
-        if self.pad_to_patch_size:
-            # Modify H, W to multiple of patch size.
-            if H % self.patch_size[0] != 0:
-                x = F.pad(
-                    x, (0, 0, 0, self.patch_size[0] - H % self.patch_size[0]))
-            if W % self.patch_size[1] != 0:
-                x = F.pad(
-                    x, (0, self.patch_size[1] - W % self.patch_size[1], 0, 0))
-
-        x = self.projection(x)
-        self.DH, self.DW = x.shape[2], x.shape[3]
-        x = x.flatten(2).transpose(1, 2)
-
-        if self.norm is not None:
-            x = self.norm(x)
-
-        return x


### PR DESCRIPTION
## Motivation

- `PatchEmbed` and `PatchMerging` are basic modules that would be used in many transformer methods, such as PVT and Swin
At the same time, `AdaptivePadding` is an essential feature to deal with the dynamic shape in detection. 
- We should assert some cases in `init_wegits` and print more detailed logger messages.
## Modification

- Add `AdaptivePadding` to avoid lost pixel of input when doing the patchembed or patchmerge. 
- Add`PatchEmbed` and `PatchMerging`  to `/mmdet/models/utils/transformer.py` and add the corresponding unitests.
- Always apply adaptive padding first before doing the `PatchEmbed` and `PatchMerging` to deal with the dynamic shape in detection.
- Assert only support `Pretrain` initialization and add a new argument named `convert_weights` 

## BC-breaking (Optional)
None